### PR TITLE
Add interactive runner selection and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Dash-Dot Chain Rewriter
+
+This repository contains a small utility for rewriting *dash‑dot* chains. A
+chain is a sequence of digits, centred bullet characters (`•`) and dashes
+(`-`). The `chain.py` module provides a set of rewrite rules and a number of
+runners that demonstrate different ways to apply them.
+
+## Usage
+
+The module can be executed directly with a mode and an initial chain:
+
+```bash
+python chain.py run '•0-0-3-5•2'
+```
+
+Available modes are:
+
+- `step` – apply a single rewrite step
+- `run` – display every intermediate chain
+- `interactive` – as above but waits for Enter between steps
+- `last` – only print the final chain
+- `run_abridged` – omit large expansions while streaming output
+- `interactive_abridged` – interactive variant of the abridged runner
+
+If the script is run without arguments it will prompt for the desired runner
+and the starting chain interactively.
+
+## Development
+
+Run the unit tests with:
+
+```bash
+pytest
+```
+
+The tests cover the core rewrite logic.

--- a/chain.py
+++ b/chain.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Chain rewriting utility for dash-dot syntax.
 
 Chains are sequences consisting of digits, centered bullets ("\u2022"), and
@@ -354,27 +355,38 @@ def interactive_abridged(chain: str) -> None:
 # CLI interface
 if __name__ == '__main__':
     import sys
-    if len(sys.argv) != 3 or sys.argv[1] not in (
-            'step', 'run', 'interactive', 'last',
-            'run_abridged', 'interactive_abridged'):
-        print(
-            "Usage: python chain.py"
-            " [step|run|interactive|last|run_abridged|interactive_abridged] '<chain>'"
-        )
+
+    runners = {
+        'step': None,  # handled specially
+        'run': run_verbose,
+        'interactive': run_interactive,
+        'last': run_last,
+        'run_abridged': run_abridged,
+        'interactive_abridged': interactive_abridged,
+    }
+
+    if len(sys.argv) == 1:
+        print("Available modes:")
+        names = list(runners)
+        for i, name in enumerate(names, 1):
+            print(f"{i}. {name}")
+        choice = input("Choose mode: ").strip()
+        if choice.isdigit() and 1 <= int(choice) <= len(names):
+            mode = names[int(choice) - 1]
+        else:
+            mode = choice
+        raw = input("Enter chain: ").strip()
+    elif len(sys.argv) == 3 and sys.argv[1] in runners:
+        mode, raw = sys.argv[1], sys.argv[2]
+    else:
+        opts = '|'.join(runners.keys())
+        print(f"Usage: python chain.py [{opts}] '<chain>'")
         sys.exit(1)
-    mode, raw = sys.argv[1], sys.argv[2]
+
     chain = _normalize(raw)
     if mode == 'step':
         out = rewrite_step(chain)
         print(out if out else "(no rule applies)")
-    elif mode == 'run':
-        run_verbose(chain)
-    elif mode == 'interactive':
-        run_interactive(chain)
-    elif mode == 'last':
-        run_last(chain)
-    elif mode == 'run_abridged':
-        run_abridged(chain)
     else:
-        interactive_abridged(chain)
+        runners[mode](chain)
 


### PR DESCRIPTION
## Summary
- create README with basic usage instructions
- add interactive runner prompt when `chain.py` is executed without arguments
- declare UTF-8 encoding to avoid SyntaxError on Python 2

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877d9f8a738832593ad87600ce6df4f